### PR TITLE
Revert "Bump highlight.js from 9.18.1 to 9.18.5"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5802,9 +5802,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.18.5",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
-      "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==",
+      "version": "9.18.1",
+      "resolved": "https://registry.npm.taobao.org/highlight.js/download/highlight.js-9.18.1.tgz",
+      "integrity": "sha1-7SGqAB/mJSuxCj121HVzxlOf4Tw=",
       "dev": true
     },
     "hmac-drbg": {


### PR DESCRIPTION
Reverts northerlyStar/northerlyStar.github.io#5